### PR TITLE
feat: 添加多种图片黑白转换方式和实时预览功能

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # 图像处理
 Pillow>=10.0.0
+numpy>=1.24.0
+scipy>=1.10.0
 
 # HTTP请求
 requests>=2.31.0


### PR DESCRIPTION
## 新增功能

- 添加7种图片黑白转换算法：
  * 阈值法（手动调整）
  * Floyd-Steinberg抖动
  * 有序抖动
  * 自适应阈值
  * Otsu自动阈值
  * Atkinson抖动（复古Mac风格）
  * 边缘保留（适合线稿）

- 添加转换方式下拉菜单，支持实时切换
- 添加阈值调整滑块，支持实时预览
- 自动处理图片：转换为黑白并调整为596x832尺寸
- 支持多种图片格式输入（jpg、png、bmp等）

## 技术改进

- 添加numpy和scipy依赖用于高级图像处理
- 优化图片处理流程，保存原始图片用于重新处理
- 实现多种抖动算法和边缘检测算法

## 测试

已在 macOS 上测试所有转换方式，预览功能正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)